### PR TITLE
Track lead ID on client side

### DIFF
--- a/server/modules/form/api.js
+++ b/server/modules/form/api.js
@@ -33,13 +33,14 @@ export default {
 		let cacheToken;
 
 		try {
-			const marketoResponse = await (req.query.pa11y ? Promise.resolve() : Marketo.createOrUpdate(req.body));
+			const { id } = await (req.query.pa11y ? Promise.resolve() : Marketo.createOrUpdate(req.body));
 
 			if (res.locals.contentUuid){
 				const { accessToken } = await Content.createAccessToken({
 					uuid: res.locals.contentUuid
 				});
 				cacheToken = Cache.set({
+					leadId: id,
 					contentUuid: res.locals.contentUuid,
 					accessToken
 				});
@@ -77,7 +78,7 @@ export default {
 	confirm: async (req, res, next) => {
 
 		const template = 'confirm';
-		const { contentUuid, accessToken } = res.locals.submission;
+		const { leadId, contentUuid, accessToken } = res.locals.submission;
 		let article;
 
 		try {
@@ -89,6 +90,7 @@ export default {
 				title: 'Signup',
 				layout: 'wrapper',
 				wrapped: true,
+				leadId,
 				article,
 				accessToken
 			});

--- a/views/confirm.html
+++ b/views/confirm.html
@@ -1,4 +1,4 @@
-<div class="o-grid-container {{#if wrapped}}confirmation--wrapped{{/if}}" data-submission-token="{{cacheToken}}" data-trackable-page="confirmation">
+<div class="o-grid-container {{#if wrapped}}confirmation--wrapped{{/if}}" data-trackable-lead-id="{{leadId}}" data-submission-token="{{cacheToken}}" data-trackable-page="confirmation">
 	<div class="o-grid-row o-grid-row--compact">
 		<div data-o-grid-colspan="center 10 S8"><h1 class="confirmation__title">Thank you for your enquiry</h1></div>
 	</div>

--- a/views/form.html
+++ b/views/form.html
@@ -1,6 +1,7 @@
 <form method="POST" data-trackable-page="form" data-trackable="b2b-prospect-form" data-o-component="o-forms">
 
 	<input type="hidden" name="numberOfEmployees" value="0" />
+	<input type="hidden" name="rating" value="propensity organic form" />
 	<input type="hidden" name="leadSource" value="FT.com" />
 	<input type="hidden" name="Industry_Sector__c" value="null" />
 	<input type="hidden" name="Lead_Type__c" value="Corporate" />


### PR DESCRIPTION
Plus `rating` field for Salesforce tracking (hopefully)