### PR TITLE
migrate to n-ui v7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "next-b2b-prospect",
   "dependencies": {
-    "n-ui": "^6.4.3",
+    "n-ui": "^7.0.0",
     "o-buttons": "^5.0.0",
     "o-forms": "^4.0.0",
     "o-colors": "^4.0.0",

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 8.1.4
+    version: 8.7.0
 deployment:
   production:
     branch: master

--- a/client/main.js
+++ b/client/main.js
@@ -1,3 +1,4 @@
+import { onAppInitialized } from 'n-ui';
 import FormComponent from './components/form';
 import SubmissionComponent from './components/submission';
 import ConfirmationComponent from './components/confirmation';
@@ -17,3 +18,5 @@ if (submissionEl) {
 if (confirmationEl) {
 	ConfirmationComponent.init(confirmationEl);
 }
+
+onAppInitialized();

--- a/client/n-ui-config.js
+++ b/client/n-ui-config.js
@@ -1,8 +1,0 @@
-module.exports = {
-	preset: 'vanilla', // 'discrete' will turn off ads & various popups
-	features: {
-		header: false,
-		footer: false,
-		cookie: false
-	}
-}

--- a/n-ui-build.config.js
+++ b/n-ui-build.config.js
@@ -1,6 +1,4 @@
 module.exports = {
-	withBabelPolyfills: true,
-	withHashedAssets: true,
 	entry: {
 		'./public/main.js': './client/main.js',
 		'./public/main.css': './client/main.scss'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Alex Naish",
   "license": "ISC",
   "engines": {
-    "node": "^8.4.0"
+    "node": "^8.7.0"
   },
   "scripts": {
     "precommit": "node_modules/.bin/secret-squirrel",
@@ -17,12 +17,12 @@
     "@financial-times/n-es-client": "^1.4.0",
     "@financial-times/n-mask-logger": "^2.0.3",
     "@financial-times/n-raven": "^3.0.0",
-    "@financial-times/n-ui": "^6.20.1",
+    "@financial-times/n-ui": "^7.0.0",
     "body-parser": "^1.18.2",
     "cookie-parser": "^1.4.3",
     "fetchres": "^1.7.2",
-    "forever": "^0.15.1",
-    "joi": "^13.0.0",
+    "forever": "^0.15.3",
+    "joi": "^13.0.1",
     "lodash": "^4.17.4",
     "n-health": "^2.1.0",
     "node-marketo-rest": "^0.3.7"
@@ -35,7 +35,7 @@
     "chai": "^4.1.2",
     "mocha": "^4.0.1",
     "nodemon": "^1.12.1",
-    "pa11y-ci": "^1.2.0",
+    "pa11y-ci": "^1.3.0",
     "proxyquire": "^1.8.0",
     "sinon": "^4.0.1",
     "supertest": "^3.0.0"

--- a/server/app.js
+++ b/server/app.js
@@ -14,6 +14,14 @@ const app = express({
 	withBackendAuthentication: false
 });
 
+app.locals.nUiConfig = {
+	preset: 'discrete', 
+	features: {
+		header: false,
+		footer: false
+	}
+};
+
 app.use(cookieParser());
 app.use(bodyParser.urlencoded({ extended: false }))
 


### PR DESCRIPTION
 Migration guide for reference: Financial-Times/n-ui#1012 (comment)

Tech debt:
- Proper `n-ui` bootstrapping / performance marking

I am unfamiliar with this app, could you please check out locally and see that it looks as you'd expect it to?
