### PR TITLE
Resolve n-ui-foundations bower conflict

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,5 +8,8 @@
     "o-typography": "^5.0.0",
     "o-grid": "^4.3.3",
     "o-loading": "^2.1.0"
+  },
+  "resolutions": {
+    "n-ui-foundations": "^2.4.3"
   }
 }


### PR DESCRIPTION
This allows us to gradually move to n-ui-foundations v3 for some of the
repos in which there are no breaking changes (and hence should not get
their own major version bump).
 🐿 v2.5.16