### PR TITLE
update marketo consent fields validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ public
 package-lock.json
 .pa11yci.js
 pa11y*
+tmp

--- a/package.json
+++ b/package.json
@@ -15,29 +15,29 @@
   },
   "dependencies": {
     "@financial-times/n-cluster": "^1.0.0",
-    "@financial-times/n-es-client": "^1.4.0",
+    "@financial-times/n-es-client": "^1.6.1",
     "@financial-times/n-mask-logger": "^2.1.0",
-    "@financial-times/n-raven": "^3.0.0",
-    "@financial-times/n-ui": "^8.6.7",
-    "body-parser": "^1.18.2",
+    "@financial-times/n-raven": "^3.0.3",
+    "@financial-times/n-ui": "^8.8.0",
+    "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.3",
     "fetchres": "^1.7.2",
-    "joi": "^13.0.1",
-    "lodash": "^4.17.4",
-    "n-health": "^2.1.0",
-    "node-marketo-rest": "^0.3.7"
+    "joi": "^13.3.0",
+    "lodash": "^4.17.10",
+    "n-health": "^2.3.2",
+    "node-marketo-rest": "^0.7.0"
   },
   "devDependencies": {
     "@financial-times/fastly-tools": "^1.7.1",
     "@financial-times/n-gage": "^1.19.14",
-    "@financial-times/n-heroku-tools": "^7.1.11",
-    "bower": "^1.8.2",
+    "@financial-times/n-heroku-tools": "^7.2.0",
+    "bower": "^1.8.4",
     "chai": "^4.1.2",
     "mocha": "^4.0.1",
-    "nodemon": "^1.12.1",
+    "nodemon": "^1.17.4",
     "pa11y-ci": "^1.3.0",
     "proxyquire": "^1.8.0",
-    "sinon": "^4.0.1",
-    "supertest": "^3.0.0"
+    "sinon": "^4.5.0",
+    "supertest": "^3.1.0"
   }
 }

--- a/server/modules/marketo/constants.js
+++ b/server/modules/marketo/constants.js
@@ -4,22 +4,45 @@ export const NOT_FOUND_ERROR = 'marketo/not_found';
 export const UNEXPECTED_RESULT_ERROR = 'marketo/unexpected_result';
 export const LEAD_ALREADY_EXISTS_ERROR = 'lead_already_exists';
 
-export const SCHEMA = Joi.object().keys({
-    firstName: Joi.string().required(),
-    lastName: Joi.string().required(),
-    title: Joi.string().required(),
-    company: Joi.string().required(),
-    email: Joi.string().email().required(),
-    phone: Joi.string().min(5).max(15).regex(/^([0-9()+\- ])+$/, 'all numbers').required(),
-    country: Joi.string().required(),
-    numberOfEmployees: Joi.number().default('0'),
-    rating: Joi.string().required(),
-    Third_Party_Opt_In__c: Joi.bool().required(),
-    leadSource: Joi.string().empty('').default('FT.com'),
-    Industry_Sector__c: Joi.string().empty('').default('null'),
-    Lead_Type__c: Joi.string().empty('').default('Corporate'),
-    CPCCampaign__c: Joi.string().empty('').default(''),
-    GCLID__c: Joi.string().empty('').default(''),
-    Comments: Joi.string().empty('').default(''),
-    Job_Function__c: Joi.string().empty('').default('')
-}).rename('jobTitle', 'title', { ignoreUndefined: true });
+export const SCHEMA = Joi.object()
+	.keys({
+		firstName: Joi.string().required(),
+		lastName: Joi.string().required(),
+		title: Joi.string().required(),
+		company: Joi.string().required(),
+		email: Joi.string()
+			.email()
+			.required(),
+		phone: Joi.string()
+			.min(5)
+			.max(15)
+			.regex(/^([0-9()+\- ])+$/, 'all numbers')
+			.required(),
+		country: Joi.string().required(),
+		numberOfEmployees: Joi.number().default('0'),
+		rating: Joi.string().required(),
+		Third_Party_Opt_In__c: Joi.bool().optional(),
+		leadSource: Joi.string()
+			.empty('')
+			.default('FT.com'),
+		Industry_Sector__c: Joi.string()
+			.empty('')
+			.default('null'),
+		Lead_Type__c: Joi.string()
+			.empty('')
+			.default('Corporate'),
+		CPCCampaign__c: Joi.string()
+			.empty('')
+			.default(''),
+		GCLID__c: Joi.string()
+			.empty('')
+			.default(''),
+		Comments: Joi.string()
+			.empty('')
+			.default(''),
+		Job_Function__c: Joi.string()
+			.empty('')
+			.default('')
+	})
+	.rename('jobTitle', 'title', { ignoreUndefined: true })
+	.pattern(/Consent_\w*__\w*/, Joi.boolean());

--- a/server/modules/marketo/constants.js
+++ b/server/modules/marketo/constants.js
@@ -21,7 +21,6 @@ export const SCHEMA = Joi.object()
 		country: Joi.string().required(),
 		numberOfEmployees: Joi.number().default('0'),
 		rating: Joi.string().required(),
-		Third_Party_Opt_In__c: Joi.bool().optional(),
 		leadSource: Joi.string()
 			.empty('')
 			.default('FT.com'),
@@ -42,7 +41,9 @@ export const SCHEMA = Joi.object()
 			.default(''),
 		Job_Function__c: Joi.string()
 			.empty('')
-			.default('')
+			.default(''),
+		// TODO: GDPR cleanup
+		Third_Party_Opt_In__c: Joi.bool().optional()
 	})
 	.rename('jobTitle', 'title', { ignoreUndefined: true })
 	.pattern(/Consent_\w*__\w*/, Joi.boolean());


### PR DESCRIPTION
Background: https://github.com/Financial-Times/next-corp-signup/pull/167
- Consent is no longer binary and will not be stored in a single boolean field in Marketo.
- Optionally validate the `Third_Party_Opt_In__c` field; this will be removed in the GDPR cleanup.
- Validate that fields conforming to the structure `Consent_categoryName__channelName` are boolean values.