### PR TITLE
update marketo consent field validation

### DIFF
--- a/server/modules/marketo/constants.js
+++ b/server/modules/marketo/constants.js
@@ -46,4 +46,4 @@ export const SCHEMA = Joi.object()
 		Third_Party_Opt_In__c: Joi.bool().optional()
 	})
 	.rename('jobTitle', 'title', { ignoreUndefined: true })
-	.pattern(/Consent_\w*__\w*/, Joi.boolean());
+	.pattern(/Consent_\w*_\w*/, Joi.boolean());

--- a/test/server/modules/marketo/schema.spec.js
+++ b/test/server/modules/marketo/schema.spec.js
@@ -26,8 +26,8 @@ const marketingPayload = {
 };
 
 const consentPayload = {
-	Consent_category__channelOne: true,
-	Consent_category__channelTwo: false
+	Consent_category_channelOne: true,
+	Consent_category_channelTwo: false
 };
 
 describe('Marketo Service Payload Schema', () => {
@@ -56,7 +56,7 @@ describe('Marketo Service Payload Schema', () => {
 	});
 
 	it('Validates consent payload', () => {
-		validPayload.Consent_category__channelOne = 'invalid';
+		validPayload.Consent_category_channelOne = 'invalid';
 		const { error, value } = Joi.validate(validPayload, SCHEMA, {
 			abortEarly: false
 		});


### PR DESCRIPTION
We have confirmation over the Marketo fields, structure is `Consent_categoryName_channelName` (single underscores).
 🐿 v2.8.0