### PR TITLE
create or update option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ Embeddable B2B Prospect form which creates a unique lead Marketo.
 
 ### Run locally
 `make build run` then access the form locally at `https://local.ft.com:3002/form`
+
+### Endpoints
+
+*	`GET /form`
+	*	Renders the "Contact Form"
+	* Pushes the lead data into Marketo
+*	`POST /api/marketo`
+	*	Marketo Interface to create or update leads
+	* Has strict validation in place to prevent extra or  invalid fields.

--- a/server/modules/api/api.js
+++ b/server/modules/api/api.js
@@ -6,24 +6,24 @@ const logger = new MaskLogger(['firstName', 'lastName', 'email']);
 
 export default {
 
-    marketo: async (req, res, next) => {
+	marketo: async (req, res, next) => {
 
-        try {
-            const marketoResponse = await Marketo.createOrUpdate(res.locals.payload);
-            return res.status(200).json({
-                details: Object.assign(res.locals.payload, marketoResponse)
-            });
+		try {
+			const marketoResponse = await Marketo.createOrUpdate(res.locals.payload, { allowUpdates: req.query.allowUpdates === 'true' } );
+			return res.status(200).json({
+				details: Object.assign(res.locals.payload, marketoResponse)
+			});
 
-        } catch (error) {
-            logger.error(`marketo api - Error submitting to Marketo: ${error.message}`);
-            raven.captureError(error);
-            return res.status(500).json({
-                error: 'MarketoError',
-                type: error.type,
-                message: error.message,
-                reason: error.reason
-            });
-        }
-    }
+		} catch (error) {
+			logger.error(`marketo api - Error submitting to Marketo: ${error.message}`);
+			raven.captureError(error);
+			return res.status(500).json({
+				error: 'MarketoError',
+				type: error.type,
+				message: error.message,
+				reason: error.reason
+			});
+		}
+	}
 
 }

--- a/server/modules/api/api.js
+++ b/server/modules/api/api.js
@@ -9,7 +9,7 @@ export default {
 	marketo: async (req, res, next) => {
 
 		try {
-			const marketoResponse = await Marketo.createOrUpdate(res.locals.payload, { allowUpdates: req.query.allowUpdates === 'true' } );
+			const marketoResponse = await Marketo.createOrUpdate(res.locals.payload);
 			return res.status(200).json({
 				details: Object.assign(res.locals.payload, marketoResponse)
 			});

--- a/server/modules/marketo/constants.js
+++ b/server/modules/marketo/constants.js
@@ -43,7 +43,7 @@ export const SCHEMA = Joi.object()
 			.empty('')
 			.default(''),
 		// TODO: GDPR cleanup
-		Third_Party_Opt_In__c: Joi.bool().optional()
+		Third_Party_Opt_In__c: Joi.bool().optional(),
 	})
 	.rename('jobTitle', 'title', { ignoreUndefined: true })
 	.pattern(/Consent_\w*_\w*/, Joi.boolean());

--- a/server/modules/marketo/service.js
+++ b/server/modules/marketo/service.js
@@ -12,7 +12,7 @@ if (!endpoint || !identity || !clientId || !clientSecret){
 }
 const marketo = new Marketo({ endpoint, identity, clientId, clientSecret });
 
-const parseResult = ({ result = [] } = {}, allowUpdates = false) => {
+const parseResult = ({ result = [] } = {}) => {
 
 	if (result.length <= 0) {
 		const error = new Error('No results returned');
@@ -33,7 +33,7 @@ const parseResult = ({ result = [] } = {}, allowUpdates = false) => {
 		throw error;
 	}
 
-	if ((!allowUpdates && res.status !== 'created') || (allowUpdates && res.status !== 'created' && res.status !== 'updated')) {
+	if (res.status !== 'created' && res.status !== 'updated') {
 		const error = new Error('Marketo errored');
 		error.type = constants.UNEXPECTED_RESULT_ERROR;
 		error.reason = res.reasons;
@@ -49,10 +49,9 @@ export default {
 		return Joi.validate(payload, constants.SCHEMA, { abortEarly: false });
 	},
 
-	createOrUpdate: (payload, { allowUpdates } = {}) => {
-		const action = allowUpdates ? 'createOrUpdate' : 'createOnly';
-		return marketo.lead.createOrUpdate([ payload ], { action: action, lookupField: 'email' })
-			.then(res => parseResult(res, allowUpdates));
+	createOrUpdate: (payload) => {
+		return marketo.lead.createOrUpdate([ payload ], { lookupField: 'email' })
+			.then(parseResult);
 	}
 
 

--- a/test/server/modules/api/api.spec.js
+++ b/test/server/modules/api/api.spec.js
@@ -12,11 +12,11 @@ import Marketo from '../../../../server/modules/marketo/service';
 import raven from '@financial-times/n-raven';
 
 describe('API Endpoints', () => {
-    
+
     before(() => ready);
 
     describe('Marketo', () => {
-        
+
         let sandbox;
         let marketoStub;
         let ravenStub;
@@ -48,7 +48,7 @@ describe('API Endpoints', () => {
         };
 
         beforeEach(() => {
-            sandbox = sinon.sandbox.create();
+            sandbox = sinon.createSandbox();
             marketoStub = sandbox.stub(Marketo, 'createOrUpdate').resolves(mockMarketoResponse);
             ravenStub = sandbox.stub(raven, 'captureError');
         });
@@ -116,7 +116,7 @@ describe('API Endpoints', () => {
         context('when a marketo error happens', () => {
 
             beforeEach(() => {
-                Marketo.createOrUpdate.rejects({});                
+                Marketo.createOrUpdate.rejects({});
             });
 
             it('should return a 500 status and error details', (done) => {

--- a/test/server/modules/content/service.spec.js
+++ b/test/server/modules/content/service.spec.js
@@ -6,7 +6,7 @@ import AccessService from '../../../../server/modules/content/service'
 
 describe('Content Access Service', () => {
 
-	const sandbox = sinon.sandbox.create();
+	const sandbox = sinon.createSandbox();
 	const mockProcessVar = 'test';
 	const mockResponse = '{}';
 	let fetchStub;

--- a/test/server/modules/encoding/service.spec.js
+++ b/test/server/modules/encoding/service.spec.js
@@ -5,7 +5,7 @@ import Encoder from '../../../../server/modules/encoding/service';
 
 describe('Encoder Service', () => {
 
-	const sandbox = sinon.sandbox.create();
+	const sandbox = sinon.createSandbox();
 	let bufferStub;
 	let toStringStub;
 

--- a/test/server/modules/es/service.spec.js
+++ b/test/server/modules/es/service.spec.js
@@ -6,7 +6,7 @@ import service from '../../../../server/modules/es/service'
 
 describe('ES Service', () => {
 
-	const sandbox = sinon.sandbox.create();
+	const sandbox = sinon.createSandbox();
 	let esStub;
 
 	beforeEach(() => {

--- a/test/server/modules/form/api.spec.js
+++ b/test/server/modules/form/api.spec.js
@@ -91,7 +91,8 @@ describe('Form', () => {
 
 		const mockAccessToken = 'heyhoaccessforyo';
 		const mockCacheToken = 'gottacachethemall';
-		const mockMarketoResponse = { id: 'test' };
+		const mockMarketoCreatedResponse = { id: 'test', status: 'created' };
+		const mockMarketoUpdatedResponse = { id: 'test', status: 'updated' };
 		let sandbox;
 		let marketoStub;
 		let profileStub;
@@ -101,8 +102,8 @@ describe('Form', () => {
 		let testPayload;
 
 		beforeEach(() => {
-			sandbox = sinon.sandbox.create();
-			marketoStub = sandbox.stub(Marketo, 'createOrUpdate').returns(Promise.resolve(mockMarketoResponse));
+			sandbox = sinon.createSandbox();
+			marketoStub = sandbox.stub(Marketo, 'createOrUpdate').returns(Promise.resolve(mockMarketoCreatedResponse));
 			profileStub = sandbox.stub(Profile, 'save').resolves();
 			accessStub = sandbox.stub(ContentAccess, 'createAccessToken').returns(Promise.resolve({ accessToken: mockAccessToken }));
 			cacheEncodeStub = sandbox.stub(Cache, 'encode').returns(mockCacheToken);
@@ -188,7 +189,7 @@ describe('Form', () => {
 					expect(res.headers['set-cookie'][0]).to.match(new RegExp(`PROSPECT_SUBMISSION=${mockCacheToken}`));
 					expect(cacheEncodeStub.calledOnce).to.equal(true);
 					expect(cacheEncodeStub.calledWith({
-						leadId: mockMarketoResponse.id,
+						leadId: mockMarketoCreatedResponse.id,
 						marketingName: 'foo',
 						contentUuid: mockUuid,
 						accessToken: mockAccessToken
@@ -235,9 +236,7 @@ describe('Form', () => {
 		context('when user already exists', () => {
 
 			beforeEach(() => {
-				marketoStub.returns(Promise.reject({
-					type: errors.LEAD_ALREADY_EXISTS_ERROR
-				}));
+				marketoStub.resolves(mockMarketoUpdatedResponse);
 			});
 
 			it('should display a page indicating the user already exists', (done) => {
@@ -293,7 +292,7 @@ describe('Form', () => {
 		let esStub;
 
 		beforeEach(() => {
-			sandbox = sinon.sandbox.create();
+			sandbox = sinon.createSandbox();
 			cacheDecodeStub = sandbox.stub(Cache, 'decode').returns(mockCacheItem);
 			esStub = sandbox.stub(ES, 'get').returns(Promise.resolve(mockContentItem));
 		});

--- a/test/server/modules/marketo/service.spec.js
+++ b/test/server/modules/marketo/service.spec.js
@@ -10,7 +10,7 @@ describe('Marketo Service', () => {
 
 	describe('createOrUpdate', () => {
 
-		const sandbox = sinon.sandbox.create();
+		const sandbox = sinon.createSandbox();
 		const mockResponse = {
 			result: [
 				{
@@ -41,7 +41,7 @@ describe('Marketo Service', () => {
 					// First argument should be an array of the payload
 					expect(args[0]).to.deep.equal([param]);
 					// Second
-					expect(args[1]).to.deep.equal({ action: 'createOnly', lookupField: 'email' });
+					expect(args[1]).to.deep.equal({ lookupField: 'email' });
 				});
 		});
 

--- a/test/server/modules/profile/service.spec.js
+++ b/test/server/modules/profile/service.spec.js
@@ -4,7 +4,7 @@ import service from '../../../../server/modules/profile/service';
 
 describe('Profile Service', () => {
     describe('save', () => {
-        const sandbox = sinon.sandbox.create();
+        const sandbox = sinon.createSandbox();
 
 		beforeEach(() => {
 			sandbox.stub(global, 'fetch').resolves();
@@ -13,7 +13,7 @@ describe('Profile Service', () => {
 		afterEach(() => {
 			sandbox.restore();
         });
-        
+
         it('should reject before sending a response if no session', done => {
             service.save('', {})
                 .catch(() => {


### PR DESCRIPTION
Historically, we've only ever wanted the Marketo API to create a new lead and return an error if the user already existed. This was to attempt to minimise abuse of the "register your interest and get a free article" work.

Now on corp-signup, we want the ability to create OR update if already existing.


 🐿 v2.9.0