### PR TITLE
Timeout marketo after 8000ms

### DIFF
--- a/server/modules/marketo/constants.js
+++ b/server/modules/marketo/constants.js
@@ -2,6 +2,7 @@ import Joi from 'joi';
 
 export const NOT_FOUND_ERROR = 'marketo/not_found';
 export const UNEXPECTED_RESULT_ERROR = 'marketo/unexpected_result';
+export const API_TIMEOUT_ERROR = 'marketo/timeout';
 export const LEAD_ALREADY_EXISTS_ERROR = 'lead_already_exists';
 
 export const SCHEMA = Joi.object()

--- a/test/server/modules/marketo/service.spec.js
+++ b/test/server/modules/marketo/service.spec.js
@@ -116,6 +116,36 @@ describe('Marketo Service', () => {
 
 		});
 
+		context.only('when marketo times out', () => {
+
+			let clock;
+
+			beforeEach(() => {
+					clock = sinon.useFakeTimers();
+					createLeadStub.callsFake(() => {
+						return new Promise(resolve => {
+							setTimeout(() => {
+								return resolve(mockResponse);
+							}, 20000)
+						});
+					});
+			});
+
+			afterEach(() => {
+				clock.restore();
+			});
+
+			it('after 8 seconds should return a timeout status error', () => {
+					const promise = service.createOrUpdate();
+					clock.tick(8000);
+					return promise
+						.catch((err) => {
+							expect(err.type).to.equal(constants.API_TIMEOUT_ERROR);
+						});
+			});
+
+	});
+
 	});
 
 });

--- a/test/server/modules/marketo/service.spec.js
+++ b/test/server/modules/marketo/service.spec.js
@@ -144,7 +144,7 @@ describe('Marketo Service', () => {
 						});
 			});
 
-	});
+		});
 
 	});
 


### PR DESCRIPTION
**Description**

We recently suffered 503s on B2B-prospect due to Marketo being down and taking a long time to respond (if ever). Due to this, since there is no timeout set within the `node-marketo-rest` library, we waited for it to respond long enough for Fastly to kill the connection.

**Ticket**

https://trello.com/c/TYOXcnxO/497-no-timeout-set-on-b2b-prospect-which-is-causing-issues-with-unmasking-midstep-form?menu=filter&filter=member:alexnaish2


 🐿 v2.10.1