### PR TITLE
Remove references to channelsBarrierConsent flag

### DIFF
--- a/server/modules/form/api.js
+++ b/server/modules/form/api.js
@@ -21,7 +21,6 @@ export default {
 
 		logger.info({
 			event: 'RENDER_B2B_FORM',
-			gdprFlag: res.locals.flags.channelsBarrierConsent,
 			sessionPresent: !!req.cookies.FTSession_s,
 			marketingName: res.locals.marketingName
 		});
@@ -30,22 +29,19 @@ export default {
 			res.clearCookie(ERROR_COOKIE);
 		}
 
-		if (res.locals.flags.channelsBarrierConsent) {
-			try {
-				const fow = await getFormOfWords(FORM_OF_WORDS);
+		try {
+			const fow = await getFormOfWords(FORM_OF_WORDS);
 
-				consent = consentUtil.populateConsentModel({
-					fow,
-					source: CONSENT_SOURCE,
-					elementAttrs: [{ name: 'required' }]
-				});
-			} catch (e) {
-				logger.error({
-					event:'RETRIEVE_FORM_OF_WORDS_FAILURE',
-					error: e.name, message: e.message || e.errorMessage
-				}, e.data);
-			}
-
+			consent = consentUtil.populateConsentModel({
+				fow,
+				source: CONSENT_SOURCE,
+				elementAttrs: [{ name: 'required' }]
+			});
+		} catch (e) {
+			logger.error({
+				event:'RETRIEVE_FORM_OF_WORDS_FAILURE',
+				error: e.name, message: e.message || e.errorMessage
+			}, e.data);
 		}
 
 		const emailValue = await getUserEmail(req.cookies.FTSession_s);

--- a/test/server/modules/form/api.spec.js
+++ b/test/server/modules/form/api.spec.js
@@ -125,45 +125,40 @@ describe('Form', () => {
 				});
 		});
 
-		context('when the consent flag is on', () => {
+		it('should render consent fields if the form of words can be retrieved', done => {
+			nock(process.env.FOW_API_HOST)
+				.get('/api/v1/FTPINK/consentB2BProspect')
+				.reply(200, {
+					consents: [
+						{
+							category: 'enhancement',
+							channels: [
+								{ channel: 'byEmail' }
+							]
+						}
+					]
+				});
 
-			it('should render consent fields if the form of words can be retrieved', done => {
-				nock(process.env.FOW_API_HOST)
-					.get('/api/v1/FTPINK/consentB2BProspect')
-					.reply(200, {
-						consents: [
-							{
-								category: 'enhancement',
-								channels: [
-									{ channel: 'byEmail' }
-								]
-							}
-						]
-					});
+			request(app)
+				.get('/form?marketingName=factiva')
+				.end((err, res) => {
+					expect(res.text).to.contain('<div class="consent-form');
+					done();
+				});
+		});
 
-				request(app)
-					.get('/form?marketingName=factiva')
-					.set('FT-Flags', 'channelsBarrierConsent:on')
-					.end((err, res) => {
-						expect(res.text).to.contain('<div class="consent-form');
-						done();
-					});
-			});
+		it('should render the legacy terms and conditions section if form of words cannot be retrieved', done => {
+			nock(process.env.FOW_API_HOST)
+				.get('/api/v1/FTPINK/consentB2BProspect')
+				.reply(404);
 
-			it('should render the legacy terms and conditions section if form of words cannot be retrieved', done => {
-				nock(process.env.FOW_API_HOST)
-					.get('/api/v1/FTPINK/consentB2BProspect')
-					.reply(404);
-
-				request(app)
-					.get('/form?marketingName=factiva')
-					.set('FT-Flags', 'channelsBarrierConsent:on')
-					.end((err, res) => {
-						expect(res.text).to.not.contain('<div class="consent-form');
-						expect(res.text).to.contain('<input type="checkbox" id="termsAcceptance');
-						done();
-					});
-			});
+			request(app)
+				.get('/form?marketingName=factiva')
+				.end((err, res) => {
+					expect(res.text).to.not.contain('<div class="consent-form');
+					expect(res.text).to.contain('<input type="checkbox" id="termsAcceptance');
+					done();
+				});
 		});
 	});
 

--- a/views/form.html
+++ b/views/form.html
@@ -46,7 +46,7 @@
 
 			{{> n-conversion-forms/partials/country options=countries }}
 
-			{{#ifAll @root.flags.channelsBarrierConsent consent}}
+			{{#if consent}}
 				<div>
 				{{> n-profile-ui/templates/consent showHeading=true showSubmitButton=false formOfWords=consent isSubsection=true}}
 				</div>
@@ -58,7 +58,7 @@
 
 				{{/inline}}
 				{{/ n-conversion-forms/partials/fieldset }}
-			{{/ifAll}}
+			{{/if}}
 
 			{{#unless isUnmasking}}
 


### PR DESCRIPTION
The channelsBarrierConsent flag (https://toggler.ft.com/#channelsBarrierConsent) toggles the display of the consent fields on the B2B prospect form. It's no longer needed as the consent fields should always be displayed (as long as the corresponding form of words can be retrieved successfully).

 🐿 v2.10.3