### PR TITLE
Upgrade to Node.js 8.15.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
   container_config_node8: &container_config_node8
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8.13-browsers
+      - image: circleci/node:8.15.0-browsers
 
   container_config_lambda_node8: &container_config_lambda_node8
     working_directory: ~/project/build

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node server/init.js
+web: node --max-http-header-size=80000 server/init.js

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Alex Naish",
   "license": "ISC",
   "engines": {
-    "node": "8.13.0"
+    "node": "8.15.0"
   },
   "scripts": {
     "precommit": "node_modules/.bin/secret-squirrel",


### PR DESCRIPTION
> 🤖 This pull request was generated automatically.

The ETG are upgrading all apps to run Node.js 8.15.0 (or 10.15.1 in some cases).

We are tracking our progress in the ["Upgrade to Node.js 8.15.0" GitHub project board](https://github.com/orgs/Financial-Times/projects/39).

You don't have to do a thing, we are upgrading all our Heroku apps for you.

This release includes several security upgrades 👮. It will also let Renovate open upgrade pull requests for Node.js (see https://github.com/Financial-Times/renovate-config-next/pull/27 for more information).

### What have we changed?

* 🐛 We have patched the `Procfile` to work around the issues we have with large headers in Node.js 8.14.0, see https://github.com/Financial-Times/next-bugs/issues/222 for more information

* ⬆️ We have upgraded Node.js in `package.json` to `8.15.0`

* ⬆️ We _may_ have upgraded the version of `@financial-times/n-heroku-tools` to `^8.0.1`, which has been patched to start apps locally with `node --http-max-header-size=80000`

* ⬆️ We have patched `.circleci/config.yml` to run the build with the `circleci/node:8.15.0-browsers` Docker image