### PR TITLE
Add Snyk to project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ jobs:
       - run:
           name: shared-helper / helper-install-puppeteer-deps
           command: bash .circleci/shared-helpers/helper-install-puppeteer-deps
+      - run: snyk monitor --org=customer-products
       - run:
           name: Deploy to production
           command: make deploy

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+patch: {}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "precommit": "node_modules/.bin/secret-squirrel",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
     "prepush": "make verify -j3",
-    "heroku-postbuild": "make heroku-postbuild"
+    "heroku-postbuild": "make heroku-postbuild",
+    "prepare": "node_modules/.bin/snyk protect"
   },
   "dependencies": {
     "@financial-times/n-conversion-forms": "3.5.1",
@@ -28,7 +29,8 @@
     "lodash": "^4.17.10",
     "n-common-static-data": "github:Financial-Times/n-common-static-data.git#v1.6.2",
     "n-health": "3.2.0",
-    "node-marketo-rest": "^0.7.0"
+    "node-marketo-rest": "^0.7.0",
+    "snyk": "^1.165.2"
   },
   "devDependencies": {
     "@financial-times/fastly-tools": "^1.7.1",


### PR DESCRIPTION
We are installing [Snyk](https://snyk.io) in all of our app repos for security reasons.  It will patch or ignore known vulnerabilities. Currently Snyk is enabled on our repos (config and results can be viewed from the Snyk webpage) but we want to install it on each project for increased security when building. See https://github.com/Financial-Times/next/issues/365