### PR TITLE
Add Snyk to Project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ jobs:
       - run:
           name: shared-helper / helper-install-puppeteer-deps
           command: bash .circleci/shared-helpers/helper-install-puppeteer-deps
+      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/next-b2b-prospect
       - run:
           name: Deploy to production
           command: make deploy

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+patch: {}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "precommit": "node_modules/.bin/secret-squirrel",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
     "prepush": "make verify -j3",
-    "heroku-postbuild": "make heroku-postbuild"
+    "heroku-postbuild": "make heroku-postbuild",
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "dependencies": {
     "@financial-times/n-conversion-forms": "8.2.0",
@@ -34,6 +35,7 @@
     "@financial-times/fastly-tools": "^1.7.1",
     "@financial-times/n-gage": "^3.0.0",
     "@financial-times/n-heroku-tools": "^8.0.0",
+    "@financial-times/n-test": "^1.13.2",
     "bower": "^1.8.4",
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
@@ -42,8 +44,8 @@
     "pa11y-ci": "^2.1.1",
     "proxyquire": "^2.0.1",
     "sinon": "^5.0.7",
+    "snyk": "^1.167.0",
     "supertest": "^3.1.0",
-    "supertest-parse": "^1.0.0",
-    "@financial-times/n-test": "^1.13.2"
+    "supertest-parse": "^1.0.0"
   }
 }


### PR DESCRIPTION
We are installing [Snyk](https://snyk.io) in all of our app repos for security reasons. It will patch or ignore known vulnerabilities. Currently Snyk is enabled on our repos (config and results can be viewed from the Snyk webpage) but we want to install it on each project for increased security when building. See https://github.com/Financial-Times/next/issues/365