### PR TITLE
add graphiteName field to n-express options

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ const PORT = Number(process.env.PORT || 5657);
 
 const app = express({
 	systemCode: 'next-b2b-prospect',
+	graphiteName: 'b2b-prospect',
 	withJsonLd: false,
 	healthChecks: nHealth(path.resolve(__dirname, './config/health-checks')).asArray(),
 	withBackendAuthentication: false,


### PR DESCRIPTION
See financial-times/n-express#563 for details.

This change requires n-express@19.22 to work but can be safely merged without it