### PR TITLE
Update the 'make run' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unit-test:
 
 run:
 	export DEBUG=ft-next-b2b-prospect-debug; \
-	nht run --https --local
+	nht run --local
 
 deploy-fastly:
 	fastly-tools deploy -e --service FASTLY_SERVICE_ID --backends cdn/backends.json --main main.vcl ./cdn/

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ make run
 
 ## Access point
 `Access the form locally via: 
-`https://local.ft.com:3002/form
+`http://local.ft.com:3002/form
 
 `Production: 
 `https://next-b2b-prospect.ft.com/form


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/dotcom-page-kit/issues/622

This app does not run on ft.com, so it can't use the next-router, so it can't run https. Update the 'make run' command accordingly. 🐿 v2.12.5