### PR TITLE
Correct README instructions to run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,13 @@ make .env # ensure environmental var dependencies exist
 
 ## Running locally
 ```
-make run 
+make run-local
 ```
 
 ## Access point
-`Access the form locally via: 
-`http://local.ft.com:3002/form
+`Access the form locally via:` http://localhost:3002/form
 
-`Production: 
-`https://next-b2b-prospect.ft.com/form
+`Production:` https://next-b2b-prospect.ft.com/form
 
 ### Endpoints
 


### PR DESCRIPTION
There is no `make run` command available, and even if you add one that is used in another repo (e.g. `next-product` - command below), you still cannot access the `/form` endpoint via `https://local.ft.com:5050/form`.

This PR revises the README so it accurately reflect the available working commands.

```
run:
	export DEBUG=ft-next-product-debug; \
	nht run --https
```