### PR TITLE
Modify smoke tests to ensure assets are loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "prepublish": "npm run snyk-protect"
   },
   "dependencies": {
-    "@financial-times/dotcom-middleware-assets": "0.5.4",
-    "@financial-times/dotcom-middleware-navigation": "0.5.4",
-    "@financial-times/dotcom-server-handlebars": "0.5.4",
-    "@financial-times/dotcom-ui-layout": "0.5.4",
-    "@financial-times/dotcom-ui-shell": "0.5.4",
+    "@financial-times/dotcom-middleware-assets": "0.5.8",
+    "@financial-times/dotcom-middleware-navigation": "0.5.8",
+    "@financial-times/dotcom-server-handlebars": "0.5.8",
+    "@financial-times/dotcom-ui-layout": "0.5.8",
+    "@financial-times/dotcom-ui-shell": "0.5.8",
     "@financial-times/n-conversion-forms": "^15.0.0-beta.1",
     "@financial-times/n-es-client": "1.7.1",
     "@financial-times/n-express": "19.22.3",
@@ -42,11 +42,11 @@
     "sucrase": "^3.10.1"
   },
   "devDependencies": {
-    "@financial-times/dotcom-build-bower-resolve": "0.5.4",
-    "@financial-times/dotcom-build-code-splitting": "0.5.4",
-    "@financial-times/dotcom-build-js": "0.5.4",
-    "@financial-times/dotcom-build-sass": "0.5.4",
-    "@financial-times/dotcom-page-kit-cli": "0.5.4",
+    "@financial-times/dotcom-build-bower-resolve": "0.5.8",
+    "@financial-times/dotcom-build-code-splitting": "0.5.8",
+    "@financial-times/dotcom-build-js": "0.5.8",
+    "@financial-times/dotcom-build-sass": "0.5.8",
+    "@financial-times/dotcom-page-kit-cli": "0.5.8",
     "@financial-times/fastly-tools": "^1.7.1",
     "@financial-times/n-gage": "^4.0.0-beta.2",
     "@financial-times/n-heroku-tools": "^8.4.0",

--- a/server/server.js
+++ b/server/server.js
@@ -37,7 +37,7 @@ app.use(navigationMiddleware.init());
 app.use(
 	assetsMiddleware.init({
 		hostStaticAssets: !isProduction,
-		publicPath: isProduction ? '/__assets/hashed/page-kit' : '/__dev/assets/b2b-prospect'
+		publicPath: isProduction ? 'https://www.ft.com/__assets/hashed/page-kit' : '/__dev/assets/b2b-prospect'
 	})
 );
 

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -2,6 +2,8 @@ const config = {
 	status: 200,
 	waitUntil: 'load',
 	elements: {
+		// Ensure global JS is initialised
+		'.js-focus-visible': true,
 		// Ensure global styles are loaded
 		// NOTE: n-test checks whether elements are visible, not whether they are in
 		// the DOM. Checking if elements are hidden should indicate that styles loaded.

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -1,8 +1,19 @@
+const config = {
+	status: 200,
+	waitUntil: 'load',
+	elements: {
+		// Ensure global styles are loaded
+		// NOTE: n-test checks whether elements are visible, not whether they are in
+		// the DOM. Checking if elements are hidden should indicate that styles loaded.
+		'.n-ui-hide-enhanced': false
+	}
+};
+
 module.exports = [
 	{
 		method: 'GET',
 		urls: {
-			'/form': 200
+			'/form': config
 		}
 	},
 	{
@@ -12,7 +23,7 @@ module.exports = [
 			'Content-Type': 'application/x-www-form-urlencoded'
 		},
 		urls: {
-			'/form?pa11y=true': 200
+			'/form?pa11y=true': config
 		}
 	}
 ];


### PR DESCRIPTION
This app has no header or footer. It is a bare-bones page exposed by another app via an iframe.

![ft-next-b2b-smoke-test-pfyn1iz herokuapp com_form](https://user-images.githubusercontent.com/10484515/73526656-93020900-4409-11ea-9ddb-af2a4b091e82.png)

In other apps we have applied the below.
```
{
	'/path': {
		status: 200,
		waitUntil: 'load',
		elements: {
			// Ensure global JS is initialised
			'[data-o-header--js]': true,
			'[data-o-footer--js]': true,
			// Ensure global styles are loaded
			// NOTE: n-test checks whether elements are visible and not whether they are in
			// the DOM. Checking if elements are hidden should tell us if styles loaded.
			'.n-ui-hide-enhanced': false
		},
		pageErrors: 0
	}
}
```

In terms of something to ensure that global JS is initialised, this app's DOM has no classes ending `--js`, so I am unsure what we can use.

Perhaps one of these classes in the `html` tags (which I am guessing are only applied in the instance that JS is available)?:
```
<html lang="en-GB" class="js enhanced js-focus-visible" style="overflow-x:hidden;background-color:#fff1e5;color:#33302e">
```