### PR TITLE
Upgrade Node v8 -> v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ references:
 
   npm_cache_keys: &npm_cache_keys
     keys:
-        - v2-dependency-npm-{{ checksum "package.json" }}-
-        - v2-dependency-npm-{{ checksum "package.json" }}
-        - v2-dependency-npm-
+        - v3-dependency-npm-{{ checksum "package.json" }}-
+        - v3-dependency-npm-{{ checksum "package.json" }}
+        - v3-dependency-npm-
 
   cache_npm_cache: &cache_npm_cache
     save_cache:
-        key: v2-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
+        key: v3-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
         paths:
         - ./node_modules/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@
 
 references:
 
-  container_config_node8: &container_config_node8
+  container_config_node12: &container_config_node12
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8.16.2-browsers
+      - image: circleci/node:12-browsers
 
-  container_config_lambda_node8: &container_config_lambda_node8
+  container_config_lambda_node12: &container_config_lambda_node12
     working_directory: ~/project/build
     docker:
-      - image: lambci/lambda:build-nodejs8.10
+      - image: lambci/lambda:build-nodejs12.x
 
   workspace_root: &workspace_root
     ~/project
@@ -60,7 +60,7 @@ version: 2
 jobs:
 
   build:
-    <<: *container_config_node8
+    <<: *container_config_node12
     steps:
       - run:
           name: Update npm
@@ -96,7 +96,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node8
+    <<: *container_config_node12
     steps:
       - *attach_workspace
       - run:
@@ -112,7 +112,7 @@ jobs:
           destination: test-results
 
   provision:
-    <<: *container_config_node8
+    <<: *container_config_node12
     steps:
       - *attach_workspace
       - run:
@@ -126,7 +126,7 @@ jobs:
           command: make test-review-app
 
   deploy:
-    <<: *container_config_node8
+    <<: *container_config_node12
     steps:
       - *attach_workspace
       - run:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Alex Naish",
   "license": "ISC",
   "engines": {
-    "node": "8.16.2"
+    "node": ">= 12.15.0"
   },
   "scripts": {
     "precommit": "node_modules/.bin/secret-squirrel",


### PR DESCRIPTION
This PR upgrades the Node version used by this app to v12, which is currently the active version.

Tested locally and 👌.

#### References:
- [Node.js: Releases (Long Term Support (LTS) schedule)](https://nodejs.org/en/about/releases).