### PR TITLE
Set Node version to 12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Alex Naish",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.15.0"
+    "node": "12.x"
   },
   "scripts": {
     "precommit": "node_modules/.bin/secret-squirrel",


### PR DESCRIPTION
Specify stricter Node version range to ensure we're using an LTS version.